### PR TITLE
Support for SEEK on Android.

### DIFF
--- a/src/java/com/android/internal/telephony/CommandException.java
+++ b/src/java/com/android/internal/telephony/CommandException.java
@@ -42,6 +42,9 @@ public class CommandException extends RuntimeException {
         MODE_NOT_SUPPORTED,
         FDN_CHECK_FAILURE,
         ILLEGAL_SIM_OR_ME,
+        MISSING_RESOURCE,
+        NO_SUCH_ELEMENT,
+        INVALID_PARAMETER,
         DIAL_MODIFIED_TO_USSD,
         DIAL_MODIFIED_TO_SS,
         DIAL_MODIFIED_TO_DIAL,
@@ -62,7 +65,8 @@ public class CommandException extends RuntimeException {
     public static CommandException
     fromRilErrno(int ril_errno) {
         switch(ril_errno) {
-            case RILConstants.SUCCESS:                       return null;
+            case RILConstants.SUCCESS:
+                return null;
             case RILConstants.RIL_ERRNO_INVALID_RESPONSE:
                 return new CommandException(Error.INVALID_RESPONSE);
             case RILConstants.RADIO_NOT_AVAILABLE:
@@ -93,6 +97,12 @@ public class CommandException extends RuntimeException {
                 return new CommandException(Error.FDN_CHECK_FAILURE);
             case RILConstants.ILLEGAL_SIM_OR_ME:
                 return new CommandException(Error.ILLEGAL_SIM_OR_ME);
+            case RILConstants.MISSING_RESOURCE:
+                 return new CommandException(Error.MISSING_RESOURCE);
+            case RILConstants.NO_SUCH_ELEMENT:
+                 return new CommandException(Error.NO_SUCH_ELEMENT);
+            case RILConstants.INVALID_PARAMETER:
+                 return new CommandException(Error.INVALID_PARAMETER);
             case RILConstants.DIAL_MODIFIED_TO_USSD:
                 return new CommandException(Error.DIAL_MODIFIED_TO_USSD);
             case RILConstants.DIAL_MODIFIED_TO_SS:

--- a/src/java/com/android/internal/telephony/CommandsInterface.java
+++ b/src/java/com/android/internal/telephony/CommandsInterface.java
@@ -1250,6 +1250,20 @@ public interface CommandsInterface {
 
     void setNetworkSelectionModeManual(String operatorNumeric, Message response);
 
+
+    /**
+     * SmartCard API related exports
+     */
+    void iccExchangeApdu(int cla, int command, int channel, int p1, int p2,
+            int p3, String data, Message response);
+
+    void iccOpenChannel(String aid, Message response);
+
+    void iccCloseChannel(int channel, Message response);
+
+    void iccGetAtr(Message response);
+
+
     /**
      * Queries whether the current network selection mode is automatic
      * or manual

--- a/src/java/com/android/internal/telephony/IccCard.java
+++ b/src/java/com/android/internal/telephony/IccCard.java
@@ -241,4 +241,43 @@ public interface IccCard {
      * @return true if ICC card is PUK2 blocked
      */
     public boolean getIccPuk2Blocked();
+
+    /**
+     * Exchange an APDU with the ICC card over a logical channel
+     *
+     * @param cla Class of the APDU command.
+     * @param command Command passed on to the ICC card.
+     * @param channel Channel id passed on to the ICC card.
+     * @param p1 P1 value of APDU command.
+     * @param p2 P2 value of APDU command.
+     * @param p3 P3 value of APDU command.
+     * @param data Data to be sent with the APDU.
+     */
+    public void exchangeApdu(int cla, int command, int channel, int p1, int p2,
+            int p3, String data, Message onComplete);
+
+    /**
+     * Opens a logical channel to the ICC card.
+     *
+     * @param aid Application Id.
+     */
+    public void openLogicalChannel(String aid, Message onComplete);
+
+    /**
+     * Closes a previously opened logical channel to the ICC card.
+     *
+     * @param channel Channel id to be closed.
+     */
+    public void closeLogicalChannel(int channel, Message onComplete);
+
+    /**
+     * Carry out a ICC I/O operation.
+     */
+    public void exchangeIccIo(int fileId, int command,
+             int p1, int p2, int p3, String pathId, Message onComplete);
+
+    /**
+     * Get ATR from ICC Card.
+     */
+    public void getAtr(Message onComplete);
 }

--- a/src/java/com/android/internal/telephony/RIL.java
+++ b/src/java/com/android/internal/telephony/RIL.java
@@ -2591,6 +2591,11 @@ public class RIL extends BaseCommands implements CommandsInterface {
             case RIL_REQUEST_SEND_SMS_EXPECT_MORE: ret =  responseSMS(p); break;
             case RIL_REQUEST_SETUP_DATA_CALL: ret =  responseSetupDataCall(p); break;
             case RIL_REQUEST_SIM_IO: ret =  responseICC_IO(p); break;
+            case RIL_REQUEST_SIM_TRANSMIT_BASIC: ret =  responseICC_IO(p); break;
+            case RIL_REQUEST_SIM_OPEN_CHANNEL: ret  = responseInts(p); break;
+            case RIL_REQUEST_SIM_CLOSE_CHANNEL: ret  = responseVoid(p); break;
+            case RIL_REQUEST_SIM_TRANSMIT_CHANNEL: ret = responseICC_IO(p); break;
+            case RIL_REQUEST_SIM_GET_ATR: ret = responseString(p); break;
             case RIL_REQUEST_SEND_USSD: ret =  responseVoid(p); break;
             case RIL_REQUEST_CANCEL_USSD: ret =  responseVoid(p); break;
             case RIL_REQUEST_GET_CLIR: ret =  responseInts(p); break;
@@ -4102,6 +4107,11 @@ public class RIL extends BaseCommands implements CommandsInterface {
             case RIL_REQUEST_SEND_SMS_EXPECT_MORE: return "SEND_SMS_EXPECT_MORE";
             case RIL_REQUEST_SETUP_DATA_CALL: return "SETUP_DATA_CALL";
             case RIL_REQUEST_SIM_IO: return "SIM_IO";
+            case RIL_REQUEST_SIM_TRANSMIT_BASIC: return "SIM_TRANSMIT_BASIC";
+            case RIL_REQUEST_SIM_OPEN_CHANNEL: return "SIM_OPEN_CHANNEL";
+            case RIL_REQUEST_SIM_CLOSE_CHANNEL: return "SIM_CLOSE_CHANNEL";
+            case RIL_REQUEST_SIM_TRANSMIT_CHANNEL: return "SIM_TRANSMIT_CHANNEL";
+            case RIL_REQUEST_SIM_GET_ATR: return "SIM_GET_ATR";
             case RIL_REQUEST_SEND_USSD: return "SEND_USSD";
             case RIL_REQUEST_CANCEL_USSD: return "CANCEL_USSD";
             case RIL_REQUEST_GET_CLIR: return "GET_CLIR";
@@ -4607,5 +4617,79 @@ public class RIL extends BaseCommands implements CommandsInterface {
         }
         pw.println(" mLastNITZTimeInfo=" + mLastNITZTimeInfo);
         pw.println(" mTestingEmergencyCall=" + mTestingEmergencyCall.get());
+    }
+
+    public void
+    iccExchangeApdu(int cla, int command, int channel, int p1, int p2, int p3,
+            String data, Message result) {
+        RILRequest rr;
+        if (channel == 0) {
+            rr = RILRequest.obtain(RIL_REQUEST_SIM_TRANSMIT_BASIC, result);
+        } else {
+            rr = RILRequest.obtain(RIL_REQUEST_SIM_TRANSMIT_CHANNEL, result);
+        }
+
+        rr.mParcel.writeInt(command);
+        rr.mParcel.writeInt(channel);
+        rr.mParcel.writeString(null);
+        rr.mParcel.writeInt(p1);
+        rr.mParcel.writeInt(p2);
+        rr.mParcel.writeInt(p3);
+        rr.mParcel.writeString(data);
+        rr.mParcel.writeString(null);
+        rr.mParcel.writeInt(cla);
+
+        if (RILJ_LOGD) riljLog(rr.serialString() + "> iccExchangeAPDU: "
+                + requestToString(rr.mRequest)
+                + "Channel 0x" + Integer.toHexString(channel) + ": "
+                + " 0x" + Integer.toHexString(cla)
+                + " 0x" + Integer.toHexString(command)
+                + " 0x" + Integer.toHexString(p1)
+                + " 0x" + Integer.toHexString(p2)
+                + " 0x" + Integer.toHexString(p3)
+                );
+
+        send(rr);
+    }
+
+    public void
+    iccOpenChannel(String aid, Message result) {
+        RILRequest rr
+                = RILRequest.obtain(RIL_REQUEST_SIM_OPEN_CHANNEL, result);
+
+        rr.mParcel.writeString(aid);
+
+        if (RILJ_LOGD) riljLog(rr.serialString() + "> iccOpenChannel: "
+                + requestToString(rr.mRequest) + " " + aid);
+
+        send(rr);
+    }
+
+    public void
+    iccCloseChannel(int channel, Message result) {
+        RILRequest rr
+                = RILRequest.obtain(RIL_REQUEST_SIM_CLOSE_CHANNEL, result);
+
+        rr.mParcel.writeInt(1);
+        rr.mParcel.writeInt(channel);
+
+        if (RILJ_LOGD) riljLog(rr.serialString() + "> iccCloseChannel: "
+                + requestToString(rr.mRequest) + " " + channel);
+
+        send(rr);
+    }
+
+    public void
+    iccGetAtr(Message result) {
+        RILRequest rr
+                = RILRequest.obtain(RIL_REQUEST_SIM_GET_ATR, result);
+        int slotId = 0;
+        rr.mParcel.writeInt(1);
+        rr.mParcel.writeInt(slotId);
+
+        if (RILJ_LOGD) riljLog(rr.serialString() + "> iccGetAtr: "
+                + requestToString(rr.mRequest) + " " + slotId);
+
+        send(rr);
     }
 }

--- a/src/java/com/android/internal/telephony/sip/SipCommandInterface.java
+++ b/src/java/com/android/internal/telephony/sip/SipCommandInterface.java
@@ -558,5 +558,22 @@ class SipCommandInterface extends BaseCommands implements CommandsInterface {
             String password, Message result) {
     }
 
+    @Override
+    public void iccExchangeApdu(int cla, int command, int channel, int p1,
+            int p2, int p3, String data, Message response) {
+    }
+
+    @Override
+    public void iccOpenChannel(String aid, Message response) {
+    }
+
+    @Override
+    public void iccCloseChannel(int channel, Message response) {
+    }
+
+    @Override
+    public void iccGetAtr(Message response) {
+    }
+
     public boolean needsOldRilFeature(String feature) { return false; }
 }

--- a/src/java/com/android/internal/telephony/test/SimulatedCommands.java
+++ b/src/java/com/android/internal/telephony/test/SimulatedCommands.java
@@ -1695,5 +1695,26 @@ public final class SimulatedCommands extends BaseCommands
         unimplemented(response);
     }
 
+    @Override
+    public void iccExchangeApdu (int cla, int command, int channel, int p1,
+            int p2, int p3, String data, Message response) {
+        unimplemented(response);
+    }
+
+    @Override
+    public void iccOpenChannel(String aid, Message response) {
+        unimplemented(response);
+    }
+
+    @Override
+    public void iccCloseChannel(int channel, Message response) {
+        unimplemented(response);
+    }
+
+    @Override
+    public void iccGetAtr(Message response) {
+        unimplemented(response);
+    }
+
     public boolean needsOldRilFeature(String feature) { return false; }
 }

--- a/src/java/com/android/internal/telephony/uicc/IccCardProxy.java
+++ b/src/java/com/android/internal/telephony/uicc/IccCardProxy.java
@@ -844,4 +844,54 @@ public class IccCardProxy extends Handler implements IccCard {
 
         pw.flush();
     }
+
+    @Override
+    public void exchangeApdu(int cla, int command, int channel, int p1, int p2,
+            int p3, String data, Message onComplete) {
+        synchronized (mLock) {
+            if (mUiccApplication != null) {
+                mUiccApplication.exchangeApdu(cla, command, channel, p1, p2, p3,
+                        data, onComplete);
+            }
+        }
+    }
+
+    @Override
+    public void openLogicalChannel(String aid, Message onComplete) {
+        synchronized (mLock) {
+            if (mUiccApplication != null) {
+                mUiccApplication.openLogicalChannel(aid, onComplete);
+            }
+        }
+    }
+
+    @Override
+    public void closeLogicalChannel(int channel, Message onComplete) {
+        synchronized (mLock) {
+            if (mUiccApplication != null) {
+                mUiccApplication.closeLogicalChannel(channel, onComplete);
+            }
+        }
+    }
+
+    @Override
+    public void exchangeIccIo(int fileId, int command,
+            int p1, int p2, int p3, String pathId, Message onComplete) {
+        synchronized (mLock) {
+            if (mUiccApplication != null) {
+                mUiccApplication.exchangeIccIo(fileId, command, p1, p2, p3,
+                        pathId, onComplete);
+            }
+        }
+    }
+
+    @Override
+    public void getAtr(Message onComplete) {
+        synchronized (mLock) {
+            if (mUiccApplication != null) {
+                mUiccApplication.getAtr(onComplete);
+            }
+        }
+    }
+
 }

--- a/tests/telephonytests/src/com/android/internal/telephony/gsm/UsimDataDownloadCommands.java
+++ b/tests/telephonytests/src/com/android/internal/telephony/gsm/UsimDataDownloadCommands.java
@@ -648,6 +648,23 @@ class UsimDataDownloadCommands extends BaseCommands {
     }
 
     @Override
+    public void iccExchangeApdu (int cla, int command, int channel, int p1,
+             int p2, int p3, String data, Message response) {
+    }
+
+    @Override
+    public void iccOpenChannel(String aid, Message response) {
+    }
+
+    @Override
+    public void iccCloseChannel(int channel, Message response) {
+    }
+
+    @Override
+    public void iccGetAtr(Message response) {
+    }
+
+    @Override
     public void setInitialAttachApn(String apn, String protocol, int authType, String username,
             String password, Message result) {
     }


### PR DESCRIPTION
Support for following apis have been added:
1. exchangeApdu()
2. openLogicalChannel()
3. closeLogicalChannel()
4. getAtr()

Conflicts:
    src/java/com/android/internal/telephony/sip/SipCommandInterface.java
    src/java/com/android/internal/telephony/test/SimulatedCommands.java

Change-Id: I267d0d6fd229f20671411b130f7654ee705f14ca
