### PR TITLE
Telephony: Decode Virgin Mobile US MMS

### DIFF
--- a/src/java/com/android/internal/telephony/VirginMobileDecoder.java
+++ b/src/java/com/android/internal/telephony/VirginMobileDecoder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2006 The Android Open Source Project
+ * Copyright (C) 2011, 2012 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.telephony;
+
+import com.android.internal.util.BitwiseInputStream;
+import com.android.internal.util.BitwiseInputStream.AccessException;
+
+public class VirginMobileDecoder {
+    /**
+     * If we have VirginMobile MMS, decode it
+     * Then, update mUserData & mMessageRef fields
+     * If not VirginMobile MMS, do nothing
+     */
+    public static void decodeMMS(SmsMessageBase sms) {
+        BitwiseInputStream inStream;
+        byte[] userData = null;
+        int ref = 0;
+        int i1 = 0;
+        int desiredBitLength = 0;
+        try {
+            inStream = new BitwiseInputStream(sms.getUserData());
+            inStream.skip(20);
+            final int j = inStream.read(8) << 8;
+            final int k = inStream.read(8);
+            ref = j | k;
+            inStream.skip(12);
+            i1 = inStream.read(8) + -2;
+            inStream.skip(13);
+            byte abyte1[] = new byte[i1];
+            for (int j1 = 0; j1 < i1; j1++) {
+                abyte1[j1] = 0;
+            }
+            desiredBitLength = i1 * 8;
+            if (inStream.available() < desiredBitLength) {
+                 return;
+            }
+            userData = inStream.readByteArray(desiredBitLength);
+        } catch (AccessException e) {
+            return;
+        }
+        sms.mUserData = userData;
+        sms.mMessageRef = ref;
+    }
+}

--- a/src/java/com/android/internal/telephony/cdma/CdmaInboundSmsHandler.java
+++ b/src/java/com/android/internal/telephony/cdma/CdmaInboundSmsHandler.java
@@ -37,6 +37,7 @@ import com.android.internal.telephony.SmsStorageMonitor;
 import com.android.internal.telephony.TelephonyProperties;
 import com.android.internal.telephony.WspTypeDecoder;
 import com.android.internal.telephony.cdma.sms.SmsEnvelope;
+import com.android.internal.telephony.VirginMobileDecoder;
 
 import java.util.Arrays;
 
@@ -180,6 +181,12 @@ public class CdmaInboundSmsHandler extends InboundSmsHandler {
             default:
                 loge("unsupported teleservice 0x" + Integer.toHexString(teleService));
                 return Intents.RESULT_SMS_UNSUPPORTED;
+        }
+
+        // Check to see if we have a Virgin Mobile MMS
+        // If so, decode it, and update mUserData/mMessageRef
+        if (sms.getOriginatingAddress().equals("9999999999")) {
+            VirginMobileDecoder.decodeMMS(sms);
         }
 
         if (!mStorageMonitor.isStorageAvailable() &&


### PR DESCRIPTION
Fixes receiving MMS as one or more sms from a 9999999999 number full of
gibberish.

Back in the CM7 days, a developer named Blarf (Blarfiejandro) started a
repo called Inferior Human Organs for the optimus S/V (LG LS670 and
VM670) when no-one could figure out how to get Virgin Mobile MMS working
in CM.

His MMS patch to decode Virgin's weird system for MMS was eventually
absorbed by CM10.2 by  rukin5197. Without it, MMS comes in as one or
more sms from a 9999999999 number full of gibberish.

bigsupersquid took the CM10.2 patch for this fix and updated it enough
to work in CM11. However because he doesn't have Gerrit, he asked others
to integrate the fix for him.

More information here:

http://forum.xda-developers.com/showthread.php?t=2663277

http://androidforums.com/virgin-mobile-galaxy-s3-all-things-root/840298-mod-universal-lte-virgin-mobile-apn-fix-wip-cm-aosp-4-4-x-2.html

Change-Id: I6518538e941fdbfb7d7441b6db49d1309e87aa9e
